### PR TITLE
Build cloudflared from source

### DIFF
--- a/cloudflare_argo/Dockerfile
+++ b/cloudflare_argo/Dockerfile
@@ -1,19 +1,27 @@
-ARG BUILD_FROM
+ARG GOLANG_VERSION=1.17
+ARG ALPINE_VERSION=3.14
+ARG BUILD_FROM=alpine:${ALPINE_VERSION}
+
+FROM golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION} as gobuild
+ARG GOLANG_VERSION
+ARG ALPINE_VERSION
+
+RUN apk add --no-cache git gcc build-base alpine-sdk; \
+  mkdir /tmp/cloudflare; \
+  cd /tmp/cloudflare; \
+  git clone https://github.com/cloudflare/cloudflared.git
+
+WORKDIR /tmp/cloudflare/cloudflared/cmd/cloudflared
+
+RUN go build ./
+
 FROM $BUILD_FROM
 
-ARG BUILD_ARCH
-RUN \
-    CVERSION="latest/download" \
-    ARCH="${BUILD_ARCH}" \
-    && if [[ "${BUILD_ARCH}" = "aarch64" ]]; then ARCH="arm64"; fi \
-    && if [[ "${BUILD_ARCH}" = "amd64" ]]; then ARCH="amd64"; fi \
-    && if [[ "${BUILD_ARCH}" = "armhf" ]]; then ARCH="arm"; fi \
-    && if [[ "${BUILD_ARCH}" = "armv7" ]]; then ARCH="arm"; fi \
-    && if [[ "${BUILD_ARCH}" = "i386" ]]; then ARCH="386"; fi \
-    && apk add --no-cache libc6-compat yq \
-    && wget -O /usr/local/bin/cloudflared https://github.com/cloudflare/cloudflared/releases/$CVERSION/cloudflared-linux-$ARCH && chmod +x /usr/local/bin/cloudflared
+RUN apk add --no-cache ca-certificates bind-tools libcap; \
+  rm -rf /var/cache/apk/*; \
+  mkdir /etc/cloudflared;
 
-RUN cloudflared -v
+COPY --from=gobuild /tmp/cloudflare/cloudflared/cmd/cloudflared/cloudflared /usr/local/bin/cloudflared
 
 COPY run.sh /
 RUN chmod a+x /run.sh

--- a/cloudflare_argo/config.json
+++ b/cloudflare_argo/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Cloudflare Argo Tunnel",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "slug": "cloudflare-argo",
   "description": "Connect to Cloudflare Argo tunnel to expose Home Assistant to the internet.",
   "url": "https://github.com/PanJ/hassio-addons",

--- a/cloudflare_argo/run.sh
+++ b/cloudflare_argo/run.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/with-contenv bashio
 
-mkdir -p /etc/cloudflared
-
 echo $(bashio::config 'credential_file_content') > /etc/cloudflared/credentials.json
 echo $(bashio::config 'config_file_content_base64') | base64 -d > /etc/cloudflared/config.yml
 


### PR DESCRIPTION
because the official binary file not support some machine architecture. e.g. raspberry pi 3 (armv6)